### PR TITLE
Get all indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@show-runner/fixturelibrary",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "openFixtureLibraryVersion": "12.3.0",
   "description": "Utility library making it easy to work with the open-fixture-library.",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@show-runner/fixturelibrary",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "openFixtureLibraryVersion": "12.3.0",
   "description": "Utility library making it easy to work with the open-fixture-library.",
   "main": "dist/src/index.js",

--- a/src/fixtureindex.ts
+++ b/src/fixtureindex.ts
@@ -10,6 +10,8 @@ export interface IndexItem {
   path?: string
   sha?: string
   url?: string
+  make?: string
+  model?: string
 }
 
 /**

--- a/src/fixturelibrary.ts
+++ b/src/fixturelibrary.ts
@@ -4,12 +4,19 @@ import addFormats from 'ajv-formats';
 import { pathExistsSync, readJSONSync } from 'fs-extra';
 import { FixtureIndex } from './fixtureindex';
 import {
-  fetchOflFixtureDirectory, githubRawFixtureRequest, request,
+  fetchOflFixtureDirectory, githubRawFixtureRequest, githubRawManufacturersRequest, request,
 } from './webhandler';
 import { Fixture } from './types';
 
 import * as schema from './ofl-schema/ofl-fixture.json';
 import fileHandler from './filehandler';
+import { Manufacturers } from './types/manufacturers';
+
+interface MakeModel {
+  key: string;
+  make: string;
+  model: string;
+}
 
 /**
  * The Fixture Library
@@ -56,6 +63,12 @@ export class FixtureLibrary {
    * Storing the Json Schema Validator object
    */
   private ajv: Ajv;
+
+  /**
+   * @internal
+   * Object for storing manufacturers at build time.
+   */
+  private manufacturers: Manufacturers = {};
 
   /**
    * @param webAccess if web requests are allowed
@@ -127,9 +140,23 @@ export class FixtureLibrary {
     return fixture;
   }
 
-  public async getIndex(): Promise<string[]> {
-    const items = await this.fixtureIndex.getIndex();
-    return Object.keys(items);
+  public getIndexItems(): MakeModel[] {
+    const index = this.fixtureIndex.getIndex();
+    const items = Object.keys(index);
+    return items.map((key) => {
+      const { make = '', model = '' } = index[key];
+      return {
+        key,
+        make,
+        model,
+      };
+    });
+  }
+
+  private getMake(path: string): string {
+    const makePath = path.split('/')?.[0]; // Gets make
+    const make = this.manufacturers[makePath];
+    return make ? make.name : '';
   }
 
   /**
@@ -148,7 +175,13 @@ export class FixtureLibrary {
     if (validate && !this.validate(fixture)) return undefined;
     // If the key is new and the definition is valid, we save it to file
     await fileHandler.writeJson(key, fixture, override);
-    this.fixtureIndex.setIndexItem(key, { path: key, sha });
+    const make = this.getMake(key);
+    this.fixtureIndex.setIndexItem(key, {
+      path: key,
+      sha,
+      model: fixture.name,
+      make,
+    });
     this.fixtureIndex.cacheFixture(key, fixture);
     await this.saveIndex();
     return fixture;
@@ -211,6 +244,8 @@ export class FixtureLibrary {
     const ofl = await fetchOflFixtureDirectory();
 
     const updatedFixtures: string[] = [];
+
+    this.manufacturers = await githubRawManufacturersRequest() as Manufacturers;
 
     await Promise.all((ofl ?? []).map(async (fixture) => {
       if (fixture.path !== 'manufacturers.json') {

--- a/src/fixturelibrary.ts
+++ b/src/fixturelibrary.ts
@@ -127,6 +127,11 @@ export class FixtureLibrary {
     return fixture;
   }
 
+  public async getIndex(): Promise<string[]> {
+    const items = await this.fixtureIndex.getIndex();
+    return Object.keys(items);
+  }
+
   /**
    * Adding a new fixture to the Library.
    * @param key new and unique fixture key

--- a/src/types/manufacturers.ts
+++ b/src/types/manufacturers.ts
@@ -1,0 +1,3 @@
+export interface Manufacturers {
+  [key: string]: { name: string };
+}

--- a/src/webhandler.ts
+++ b/src/webhandler.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import { Fixture } from './types';
 import { openFixtureLibraryVersion } from '../package.json';
+import { Manufacturers } from './types/manufacturers';
 
 interface GithubTag {
   name: string
@@ -80,6 +81,10 @@ export async function fetchLatestSupportedCommit(forceUpdate = false): Promise<s
 export async function githubRawFixtureRequest(path: string): Promise<object | void> {
   const url = `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/${await fetchLatestSupportedCommit()}/fixtures/${path}`;
   return request(url);
+}
+
+export async function githubRawManufacturersRequest(): Promise<Manufacturers | void> {
+  return githubRawFixtureRequest('manufacturers.json') as Promise<Manufacturers | void>;
 }
 
 export class TruncatedDataError extends Error {


### PR DESCRIPTION
This PR is for exposing a method to get the index keys as `make/model`.
At this point we don't need the whole fixture.

Example of the response:

```
[
  {
    key: 'american-dj/dekker-led',
    make: 'American DJ',
    model: 'Dekker LED'
  }
]
```